### PR TITLE
Move message transmitting to a Queue

### DIFF
--- a/commands/general/calculator.go
+++ b/commands/general/calculator.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 )
 
-func CalculateCommand(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func CalculateCommand(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	// this is a calculator. takes in a string, and returns an answer
 	var input = strings.Join(args, " ")
 	calculate, err := Calculate(input)

--- a/commands/general/cw.go
+++ b/commands/general/cw.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func CW(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func CW(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	var toEncode = strings.Join(args, " ")
 	// use regex to ensure that the input string can be converted to morse
 	var isValid = regexp.MustCompile(`^[a-zA-Z0-9 .,?'!/()]+$`).MatchString(toEncode)

--- a/commands/general/flip.go
+++ b/commands/general/flip.go
@@ -6,7 +6,7 @@ import (
 	"simpleAPRSbot-go/helpers/aprsHelper"
 )
 
-func Flip(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func Flip(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	// heads or tails
 	var options = [2]string{"Heads", "Tails"}
 	var decideInt = rand.IntN(1000)

--- a/commands/general/ping.go
+++ b/commands/general/ping.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func Ping(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func Ping(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	replyText := "Pong!"
 	if len(args) != 0 {
 		replyText = strings.Join(args, " ")

--- a/commands/general/roll.go
+++ b/commands/general/roll.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-func Roll(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func Roll(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	// take in 1 arg that would allow for setting max roll
 	// otherwise default to rolling out of 100
 	var maxRoll = 100

--- a/commands/general/time.go
+++ b/commands/general/time.go
@@ -21,7 +21,7 @@ var timezoneAbbrs = map[string]string{
 	"PDT": "America/Los_Angeles",
 }
 
-func Time(args []string, f aprs.Frame, client aprsHelper.APRSUserClient) {
+func Time(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient) {
 	// Default timezone to UTC
 	location := "UTC"
 

--- a/commands/location/location.go
+++ b/commands/location/location.go
@@ -8,7 +8,7 @@ import (
 	"simpleAPRSbot-go/helpers/aprsHelper"
 )
 
-func Location(args []string, f aprs.Frame, apiKey api.Keys, client aprsHelper.APRSUserClient) {
+func Location(args []string, f aprs.Frame, apiKey api.Keys, client *aprsHelper.APRSUserClient) {
 	// this command gets the user's last seen location, and returns their current zip code.
 	// step 1: get the user's last location
 

--- a/commands/location/weather.go
+++ b/commands/location/weather.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 )
 
-func Weather(args []string, f aprs.Frame, apiKey api.Keys, client aprsHelper.APRSUserClient) {
+func Weather(args []string, f aprs.Frame, apiKey api.Keys, client *aprsHelper.APRSUserClient) {
 	if len(args) < 0 {
 		// the user specified something! let's see what it was!
 		client.AprsTextReply("Not yet implemented!", f)

--- a/helpers/aprsHelper/aprsHelper.go
+++ b/helpers/aprsHelper/aprsHelper.go
@@ -149,7 +149,7 @@ func extractSSIDFromCallSSID(input string) (string, int) {
 func InitAPRSClient(callandSSID string, APRSPassword int) APRSUserClient {
 	var call, ssid = extractSSIDFromCallSSID(callandSSID)
 	var messageQueue = NewMessageQueue()
-	return APRSUserClient{callSign: call, ssid: ssid, password: APRSPassword, messageQueue: *messageQueue}
+	return APRSUserClient{callSign: call, ssid: ssid, password: APRSPassword, messageQueue: messageQueue}
 }
 
 func (client APRSUserClient) AprsTextReply(text string, f aprs.Frame) {

--- a/helpers/aprsHelper/aprsHelper.go
+++ b/helpers/aprsHelper/aprsHelper.go
@@ -88,7 +88,7 @@ func (client APRSUserClient) SendAck(f aprs.Frame) {
 		Text: ":" + EnsureLength(personWhoMessagedMe) + ":" + messageText,
 	}
 	fmt.Println(ack)
-	SendMessageFrame(ack)
+	client.MessageQueue.Push(ack)
 }
 
 func EnsureLength(input string) string {

--- a/helpers/aprsHelper/aprsHelper.go
+++ b/helpers/aprsHelper/aprsHelper.go
@@ -6,7 +6,6 @@ import (
 	"math/rand/v2"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 )
 
@@ -164,10 +163,13 @@ func (client APRSUserClient) AprsTextReply(text string, f aprs.Frame) {
 		var messages = splitStringByLength(text, 66)
 		fmt.Println("message split")
 		fmt.Println(messages)
+		var packets = make([]aprs.Frame, len(messages))
 		for _, message := range messages {
 			//fmt.Println("sending message", i, message)
-			SendMessageFrame(client.GenerateMessageReplyFrame(message, f))
-			time.Sleep(3 * time.Second)
+			packets = append(packets, client.GenerateMessageReplyFrame(message, f))
+		}
+		for _, packet := range packets {
+			client.MessageQueue.Push(packet)
 		}
 		return
 	}

--- a/helpers/aprsHelper/aprsHelper.go
+++ b/helpers/aprsHelper/aprsHelper.go
@@ -14,7 +14,7 @@ type APRSUserClient struct {
 	callSign     string
 	ssid         int
 	password     int
-	messageQueue MessageQueue
+	messageQueue *MessageQueue
 }
 
 func ExtractCommand(message string) string {
@@ -146,10 +146,10 @@ func extractSSIDFromCallSSID(input string) (string, int) {
 	return callSign, ssid
 }
 
-func InitAPRSClient(callandSSID string, APRSPassword int) APRSUserClient {
+func InitAPRSClient(callandSSID string, APRSPassword int) *APRSUserClient {
 	var call, ssid = extractSSIDFromCallSSID(callandSSID)
 	var messageQueue = NewMessageQueue()
-	return APRSUserClient{callSign: call, ssid: ssid, password: APRSPassword, messageQueue: messageQueue}
+	return &APRSUserClient{callSign: call, ssid: ssid, password: APRSPassword, messageQueue: messageQueue}
 }
 
 func (client APRSUserClient) AprsTextReply(text string, f aprs.Frame) {

--- a/helpers/aprsHelper/messageQueue.go
+++ b/helpers/aprsHelper/messageQueue.go
@@ -1,7 +1,6 @@
 package aprsHelper
 
 import (
-	"fmt"
 	"github.com/ebarkie/aprs"
 )
 
@@ -14,22 +13,20 @@ type MessageQueue struct {
 	queue []Message
 }
 
-func NewMessageQueue() MessageQueue {
+func NewMessageQueue() *MessageQueue {
 	var newQueue = MessageQueue{make([]Message, 0)}
-	return newQueue
+	return &newQueue
 }
 
-func (mq MessageQueue) Push(f aprs.Frame) {
+func (mq *MessageQueue) Push(f aprs.Frame) {
 	var m = Message{
 		Message:                 f,
 		ReceivedAcknowledgement: false,
 	}
-	fmt.Println(mq.queue, m)
 	mq.queue = append(mq.queue, m)
-	fmt.Println(mq.queue)
 }
 
-func (mq MessageQueue) Pop() aprs.Frame {
+func (mq *MessageQueue) Pop() aprs.Frame {
 	if len(mq.queue) == 0 {
 		return aprs.Frame{}
 	} else {

--- a/helpers/aprsHelper/messageQueue.go
+++ b/helpers/aprsHelper/messageQueue.go
@@ -1,6 +1,9 @@
 package aprsHelper
 
-import "github.com/ebarkie/aprs"
+import (
+	"fmt"
+	"github.com/ebarkie/aprs"
+)
 
 type Message struct {
 	Message                 aprs.Frame
@@ -8,26 +11,30 @@ type Message struct {
 }
 
 type MessageQueue struct {
-	queue []aprs.Frame
+	queue []Message
 }
 
-func NewMessageQueue() *MessageQueue {
-	return &MessageQueue{}
+func NewMessageQueue() MessageQueue {
+	var newQueue = MessageQueue{make([]Message, 0)}
+	return newQueue
 }
 
-func (mq *MessageQueue) Push(f aprs.Frame) {
-	mq.queue = append(mq.queue, f)
+func (mq MessageQueue) Push(f aprs.Frame) {
+	var m = Message{
+		Message:                 f,
+		ReceivedAcknowledgement: false,
+	}
+	fmt.Println(mq.queue, m)
+	mq.queue = append(mq.queue, m)
+	fmt.Println(mq.queue)
 }
-func (mq *MessageQueue) Pop() aprs.Frame {
+
+func (mq MessageQueue) Pop() aprs.Frame {
 	if len(mq.queue) == 0 {
 		return aprs.Frame{}
 	} else {
-		f := mq.queue[0]
+		f := mq.queue[0].Message
 		mq.queue = mq.queue[1:]
 		return f
 	}
-}
-
-func (mq *MessageQueue) Clear() {
-	mq.queue = []aprs.Frame{}
 }

--- a/helpers/aprsHelper/messageQueue.go
+++ b/helpers/aprsHelper/messageQueue.go
@@ -5,12 +5,12 @@ import (
 )
 
 type Message struct {
-	Message                 aprs.Frame
+	Message                 *aprs.Frame
 	ReceivedAcknowledgement bool
 }
 
 type MessageQueue struct {
-	queue []Message
+	Queue []Message
 }
 
 func NewMessageQueue() *MessageQueue {
@@ -20,18 +20,18 @@ func NewMessageQueue() *MessageQueue {
 
 func (mq *MessageQueue) Push(f aprs.Frame) {
 	var m = Message{
-		Message:                 f,
+		Message:                 &f,
 		ReceivedAcknowledgement: false,
 	}
-	mq.queue = append(mq.queue, m)
+	mq.Queue = append(mq.Queue, m)
 }
 
 func (mq *MessageQueue) Pop() aprs.Frame {
-	if len(mq.queue) == 0 {
+	if len(mq.Queue) == 0 {
 		return aprs.Frame{}
 	} else {
-		f := mq.queue[0].Message
-		mq.queue = mq.queue[1:]
-		return f
+		f := mq.Queue[0].Message
+		mq.Queue = mq.Queue[1:]
+		return *f
 	}
 }

--- a/helpers/aprsHelper/messageQueue.go
+++ b/helpers/aprsHelper/messageQueue.go
@@ -1,0 +1,33 @@
+package aprsHelper
+
+import "github.com/ebarkie/aprs"
+
+type Message struct {
+	Message                 aprs.Frame
+	ReceivedAcknowledgement bool
+}
+
+type MessageQueue struct {
+	queue []aprs.Frame
+}
+
+func NewMessageQueue() *MessageQueue {
+	return &MessageQueue{}
+}
+
+func (mq *MessageQueue) Push(f aprs.Frame) {
+	mq.queue = append(mq.queue, f)
+}
+func (mq *MessageQueue) Pop() aprs.Frame {
+	if len(mq.queue) == 0 {
+		return aprs.Frame{}
+	} else {
+		f := mq.queue[0]
+		mq.queue = mq.queue[1:]
+		return f
+	}
+}
+
+func (mq *MessageQueue) Clear() {
+	mq.queue = []aprs.Frame{}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"simpleAPRSbot-go/helpers/api"
 	"simpleAPRSbot-go/helpers/aprsHelper"
 	"strings"
+	"time"
 )
 
 type CommandFunc func(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient)
@@ -64,6 +65,18 @@ func main() {
 
 	// we also need to create an instance of APRSUserClient, so we can reply to messages
 	var client = aprsHelper.InitAPRSClient(*aprsCALL, *aprsPass)
+
+	go func() {
+		//queue processes
+		for {
+			if len(client.MessageQueue.Queue) < 0 {
+				continue
+			} else {
+				aprsHelper.SendMessageFrame(client.MessageQueue.Pop())
+				time.Sleep(3 * time.Second)
+			}
+		}
+	}()
 
 	log.Println("Receiving")
 	for {

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func main() {
 				continue
 			} else {
 				aprsHelper.SendMessageFrame(client.MessageQueue.Pop())
-				// this globally lets us only send a message every 3 secs. can be turned up or down based on load
-				time.Sleep(3 * time.Second)
+				// this globally lets us only send a message every x secs. can be turned up or down based on load
+				time.Sleep(1 * time.Second)
 			}
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 )
 
-type CommandFunc func(args []string, f aprs.Frame, client aprsHelper.APRSUserClient)
+type CommandFunc func(args []string, f aprs.Frame, client *aprsHelper.APRSUserClient)
 
-type CommandFuncAPIKeys func(args []string, f aprs.Frame, aprsFiKey api.Keys, client aprsHelper.APRSUserClient)
+type CommandFuncAPIKeys func(args []string, f aprs.Frame, aprsFiKey api.Keys, client *aprsHelper.APRSUserClient)
 
 var commandRegistry = map[string]CommandFunc{
 	"ping":     general.Ping,

--- a/main.go
+++ b/main.go
@@ -69,10 +69,11 @@ func main() {
 	go func() {
 		//queue processes
 		for {
-			if len(client.MessageQueue.Queue) < 0 {
+			if len(client.MessageQueue.Queue) <= 0 {
 				continue
 			} else {
 				aprsHelper.SendMessageFrame(client.MessageQueue.Pop())
+				// this globally lets us only send a message every 3 secs. can be turned up or down based on load
 				time.Sleep(3 * time.Second)
 			}
 		}


### PR DESCRIPTION
By using a queue to handle our message processing instead of just sending it, it opens up the opportunity to do things such as monitor how many messages we are sending. This queue will let us dynamically rate-limit ourselves to ensure we aren't abusing APRS or any other service. Also in the future it'll help us add monitoring for Grafana, so that's cool too.